### PR TITLE
Fixed unintended redirect on plugin details

### DIFF
--- a/src/VAXPRED/src/app/home/plugin-card/plugin-card.component.html
+++ b/src/VAXPRED/src/app/home/plugin-card/plugin-card.component.html
@@ -9,13 +9,13 @@
 		<p class="plugin-card-text"> {{ this.tool.description }} </p>
 		<div class="d-flex w-100 justify-content-around">
 			<button id="view-details-button" class="btn rounded-pill w-85" (click)="openDialog()">
-				<a href="#">
+				<a>
 					<span>View details</span>
 					<span class="ms-2 fa fa-arrow-right"></span>
 				</a>
 			</button>
 			<button id="download-button" class="btn">
-				<a href="#">
+				<a>
 					<span class="fa fa-cloud-download"></span>
 				</a>
 			</button>


### PR DESCRIPTION
'Open plugin details' button was redirecting the user to homepage.