### PR TITLE
Feat: GitHub Action for Frontend Tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,8 +8,9 @@ on:
       - dev
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: ./src/VAXPRED
@@ -25,9 +26,18 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-      
-      - name: Build
-        run: npm run build -- --configuration=ci
+
+      - name: Set up headless browser
+        run: |
+          sudo apt-get install -y xvfb
+          export DISPLAY=:99.0
+          Xvfb $DISPLAY -ac -screen 0 1024x768x16 > /dev/null 2>&1 &
+          sleep 3  # Give xvfb some time to start
 
       - name: Run AngularJS tests
-        run: npm test -- --configuration=ci
+        run: |
+          npm run test -- --browsers=ChromeHeadless --no-watch --source-map=false
+
+      - name: Cleanup
+        run: |
+          pkill -f Xvfb

--- a/src/VAXPRED/angular.json
+++ b/src/VAXPRED/angular.json
@@ -39,11 +39,6 @@
             "scripts": []
           },
           "configurations": {
-            "ci": {
-              "watch": false,
-              "progress": false,
-              "browsers": "ChromeHeadlessCI"
-            },
             "production": {
               "budgets": [
                 {


### PR DESCRIPTION
## Adds GitHub workflow to run Angular tests
Implements #152

It uses Chrome Headless Browser to run the tests.

This replicates `ng test` that we can run locally with:
`npm install`
`ng test`
